### PR TITLE
Workflow PRs target main not master

### DIFF
--- a/.github/workflows/build-cad-action.yaml
+++ b/.github/workflows/build-cad-action.yaml
@@ -5,7 +5,7 @@ on:
       - '**'
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   generate_3d_model:

--- a/.github/workflows/build-diff-action.yaml
+++ b/.github/workflows/build-diff-action.yaml
@@ -2,11 +2,11 @@ name: Build PCB Diff
 on:
   push:
     branches-ignore:
-      - master
+      - main
 
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   generate_diff:

--- a/.github/workflows/build-images-action.yaml
+++ b/.github/workflows/build-images-action.yaml
@@ -5,7 +5,7 @@ on:
       - '**'
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   generate_2d_images:

--- a/.github/workflows/build-panel-action.yaml
+++ b/.github/workflows/build-panel-action.yaml
@@ -5,7 +5,7 @@ on:
       - '**'
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   generate_panel:

--- a/.github/workflows/build-pcb-action.yaml
+++ b/.github/workflows/build-pcb-action.yaml
@@ -5,7 +5,7 @@ on:
       - '**'
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   generate_pcb:

--- a/.github/workflows/build-video-action.yaml
+++ b/.github/workflows/build-video-action.yaml
@@ -2,10 +2,10 @@ name: Generate Video Frames
 on:
   push:
     branches:
-      - master
+      - main
   # pull_request:
   #   branches:
-  #     - master
+  #     - main
 
 jobs:
   generate_video:


### PR DESCRIPTION
Workflows had their PR triggers pinned to `master`, so PRs into `main` (the default branch) ran no CI. Updates the branch filters in all six workflows to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Mt2xiQHKvSeekri8G1S4w)_