### PR TITLE
ci: bump actions/checkout v4 -> v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-cad-action.yaml
+++ b/.github/workflows/build-cad-action.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/build-diff-action.yaml
+++ b/.github/workflows/build-diff-action.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0
@@ -25,7 +25,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/build-images-action.yaml
+++ b/.github/workflows/build-images-action.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/build-panel-action.yaml
+++ b/.github/workflows/build-panel-action.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -23,7 +23,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/build-pcb-action.yaml
+++ b/.github/workflows/build-pcb-action.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/build-video-action.yaml
+++ b/.github/workflows/build-video-action.yaml
@@ -14,7 +14,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
     - name: Checkout (only last commit)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -22,7 +22,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout (full history for submodules + release notes)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
 
     - name: Clone and Checkout KiBot config
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: Cimos/kibot-config
         path: ./kibot-config


### PR DESCRIPTION
## What

Bumps `actions/checkout@v4 → @v5` across all 7 workflows (14 occurrences), resolving the Node.js 20 deprecation annotation surfaced by the v0.0.1 release run.

## Why

GitHub is forcing Node 20 actions onto Node 24 (started 2026-06-16) and removing Node 20 from runners on 2026-09-16. `checkout@v5` runs on Node 24. It's a drop-in for v4 — the only major-version change is the default Node runtime; every input in use (`submodules`, `fetch-depth`, `repository`, `path`, `ref`) is unchanged.

## Not changed (intentionally)

- `actions/upload-artifact@v4` — still the current major (no v5 exists), can't bump.
- `andstor/file-existence-action@v3` — third-party, not flagged.
- `Cimos/kibot-config@main` — Docker action, unaffected.

All 7 workflow YAMLs validated after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)