### PR TITLE
ci: warn-only ERC/DRC design-review gate with PR comment

### DIFF
--- a/.github/workflows/design-review.yaml
+++ b/.github/workflows/design-review.yaml
@@ -4,6 +4,11 @@ name: Design Review (ERC/DRC)
 # custom .kicad_dru) on pull requests, uploads the reports, and posts/updates a
 # single summary comment on the PR. It never fails the check (warn-only) — the
 # comment is the signal.
+#
+# Privilege separation: the `erc_drc` job runs the third-party kibot-config
+# action with `contents: read` ONLY. The `comment` job holds the
+# `pull-requests: write` token but runs only first-party code (gh CLI). This
+# keeps the write token out of reach of the third-party action.
 on:
   pull_request:
     branches: [main]
@@ -22,16 +27,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: read the repo, write PR comments. (Fork PRs get a read-only
-# token regardless, so the comment step is guarded + best-effort for those.)
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   erc_drc:
     name: ERC + DRC
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # third-party action runs with read-only token
+    outputs:
+      project_name: ${{ steps.proj.outputs.name }}
+      outcome: ${{ steps.checks.outcome }}
 
     steps:
     - name: Checkout
@@ -40,7 +47,8 @@ jobs:
         submodules: recursive
 
     - name: Get KiCad project name
-      run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
+      id: proj
+      run: echo "name=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_OUTPUT
 
     - name: Run ERC + DRC (warn-only)
       id: checks
@@ -49,49 +57,87 @@ jobs:
       with:
         config: design-review.kibot.yaml
         dir: design_review
-        schema: '${{ env.PROJECT_NAME }}.kicad_sch'
-        board: '${{ env.PROJECT_NAME }}.kicad_pcb'
+        schema: '${{ steps.proj.outputs.name }}.kicad_sch'
+        board: '${{ steps.proj.outputs.name }}.kicad_pcb'
         logfile: 'design_review/erc-drc.log'
 
-    - name: Assemble PR comment
+    - name: Upload ERC/DRC report
       if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: design-review-report
+        path: design_review
+
+  comment:
+    name: PR comment
+    runs-on: ubuntu-latest
+    needs: erc_drc
+    # Only same-repo PRs get a writable token; skip (don't fail) on forks.
+    if: always() && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    permissions:
+      contents: read
+      pull-requests: write     # write token here — no third-party action runs in this job
+    env:
+      PROJECT_NAME: ${{ needs.erc_drc.outputs.project_name }}
+      CHECKS_OUTCOME: ${{ needs.erc_drc.outputs.outcome }}
+
+    steps:
+    - name: Download ERC/DRC report
+      uses: actions/download-artifact@v4
+      with:
+        name: design-review-report
+        path: design_review
+
+    - name: Assemble PR comment
       run: |
         set -uo pipefail
         MARKER='<!-- kibot-design-review -->'
+        ERC="design_review/${PROJECT_NAME}-erc.txt"
+        DRC="design_review/${PROJECT_NAME}-drc.txt"
+
+        # Count severities from the KiBot report files (robust to missing files).
+        count() { if [ -f "$1" ]; then grep -cE "$2" "$1" || true; else echo 0; fi; }
+        erc_err=$(count "$ERC" '; *error');   erc_warn=$(count "$ERC" '; *warning')
+        drc_err=$(count "$DRC" '; *error');   drc_warn=$(count "$DRC" '; *warning')
+        total_err=$(( erc_err + drc_err ))
+
         {
           echo "$MARKER"
           echo "## 🔍 Design Review — ERC / DRC"
           echo
-          if [ "${{ steps.checks.outcome }}" = "success" ]; then
-            echo "✅ **ERC and DRC passed** — no errors reported."
+          if [ "$total_err" -eq 0 ]; then
+            echo "✅ **No ERC or DRC errors.** ($erc_warn ERC + $drc_warn DRC warnings — review below.)"
           else
-            echo "⚠️ **ERC and/or DRC reported issues.** This check is **warn-only** and does not block merge. Review the details below and the uploaded \`design-review-report\` artifact."
+            echo "❌ **$total_err error(s) found** ($erc_err ERC, $drc_err DRC). Warn-only — does not block merge, but please review."
           fi
           echo
-          echo "Validated with the project's custom design rules (\`${PROJECT_NAME}.kicad_dru\`)."
+          echo "| Check | Errors | Warnings |"
+          echo "| --- | --- | --- |"
+          echo "| ERC | $erc_err | $erc_warn |"
+          echo "| DRC | $drc_err | $drc_warn |"
           echo
-          echo "<details><summary>KiBot ERC/DRC log (tail)</summary>"
+          echo "_DRC run against the project's custom rules (\`${PROJECT_NAME}.kicad_dru\`). \"warn-only\" — the \`design-review-report\` artifact has the full reports._"
           echo
-          echo '```'
-          tail -n 120 design_review/erc-drc.log 2>/dev/null || echo "(no log captured)"
-          echo '```'
+          # Category breakdown — surfaces that most issues are library-sync noise vs real violations.
+          breakdown=$(cat "$ERC" "$DRC" 2>/dev/null | grep -oE '^\[[a-z_]+\]' | sort | uniq -c | sort -rn | head -12)
+          if [ -n "$breakdown" ]; then
+            echo "<details><summary>Issues by category</summary>"
+            echo; echo '```'; echo "$breakdown"; echo '```'
+            echo "</details>"
+            echo
+          fi
+          echo "<details><summary>ERC report (tail)</summary>"
+          echo; echo '```'; tail -n 60 "$ERC" 2>/dev/null || echo "(no ERC report)"; echo '```'
+          echo "</details>"
+          echo "<details><summary>DRC report (tail)</summary>"
+          echo; echo '```'; tail -n 60 "$DRC" 2>/dev/null || echo "(no DRC report)"; echo '```'
           echo "</details>"
           echo
           echo "<sub>Updated automatically on each push to this PR.</sub>"
         } > comment.md
         echo "Wrote comment.md ($(wc -l < comment.md) lines)"
 
-    - name: Upload ERC/DRC report
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.PROJECT_NAME }}-design-review-report
-        path: design_review
-
     - name: Post / update PR comment
-      # Only same-repo PRs get a writable token; skip (don't fail) on forks.
-      if: always() && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-      continue-on-error: true
       env:
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/design-review.yaml
+++ b/.github/workflows/design-review.yaml
@@ -1,0 +1,109 @@
+name: Design Review (ERC/DRC)
+
+# Warn-only design-review gate: runs KiCad ERC + DRC (using the project's
+# custom .kicad_dru) on pull requests, uploads the reports, and posts/updates a
+# single summary comment on the PR. It never fails the check (warn-only) — the
+# comment is the signal.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.kicad_pcb'
+      - '**.kicad_sch'
+      - '**.kicad_pro'
+      - '**.kicad_dru'
+      - '**.kicad_mod'
+      - '**.pretty/**'
+      - 'mad_lib/**'
+      - 'design-review.kibot.yaml'
+      - '.github/workflows/design-review.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: read the repo, write PR comments. (Fork PRs get a read-only
+# token regardless, so the comment step is guarded + best-effort for those.)
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  erc_drc:
+    name: ERC + DRC
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
+    - name: Get KiCad project name
+      run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
+
+    - name: Run ERC + DRC (warn-only)
+      id: checks
+      continue-on-error: true
+      uses: Cimos/kibot-config@main
+      with:
+        config: design-review.kibot.yaml
+        dir: design_review
+        schema: '${{ env.PROJECT_NAME }}.kicad_sch'
+        board: '${{ env.PROJECT_NAME }}.kicad_pcb'
+        logfile: 'design_review/erc-drc.log'
+
+    - name: Assemble PR comment
+      if: always()
+      run: |
+        set -uo pipefail
+        MARKER='<!-- kibot-design-review -->'
+        {
+          echo "$MARKER"
+          echo "## 🔍 Design Review — ERC / DRC"
+          echo
+          if [ "${{ steps.checks.outcome }}" = "success" ]; then
+            echo "✅ **ERC and DRC passed** — no errors reported."
+          else
+            echo "⚠️ **ERC and/or DRC reported issues.** This check is **warn-only** and does not block merge. Review the details below and the uploaded \`design-review-report\` artifact."
+          fi
+          echo
+          echo "Validated with the project's custom design rules (\`${PROJECT_NAME}.kicad_dru\`)."
+          echo
+          echo "<details><summary>KiBot ERC/DRC log (tail)</summary>"
+          echo
+          echo '```'
+          tail -n 120 design_review/erc-drc.log 2>/dev/null || echo "(no log captured)"
+          echo '```'
+          echo "</details>"
+          echo
+          echo "<sub>Updated automatically on each push to this PR.</sub>"
+        } > comment.md
+        echo "Wrote comment.md ($(wc -l < comment.md) lines)"
+
+    - name: Upload ERC/DRC report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PROJECT_NAME }}-design-review-report
+        path: design_review
+
+    - name: Post / update PR comment
+      # Only same-repo PRs get a writable token; skip (don't fail) on forks.
+      if: always() && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        MARKER: '<!-- kibot-design-review -->'
+      run: |
+        set -uo pipefail
+        existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq "[.[] | select(.body | contains(\"${MARKER}\")) | .id] | first // empty")
+        if [ -n "$existing" ]; then
+          echo "Updating existing comment $existing"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -F body=@comment.md >/dev/null
+        else
+          echo "Creating new comment"
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@comment.md >/dev/null
+        fi

--- a/design-review.kibot.yaml
+++ b/design-review.kibot.yaml
@@ -1,0 +1,17 @@
+# Project-local KiBot config for the PR design-review gate.
+#
+# The shared Cimos/kibot-config options.yaml disables validation
+# (run_erc/run_drc/check_zone_fills = false) because the datapack builds don't
+# need it. This config re-enables ERC + DRC so the gate actually validates the
+# design. DRC automatically picks up Mad_RP2040.kicad_dru (the custom JLCPCB /
+# PCBWay rules) since it lives in the project directory.
+#
+# No `outputs:` are defined on purpose — KiBot runs the preflight checks and
+# generates nothing else, keeping the gate fast (no gerbers / renders).
+kibot:
+  version: 1
+
+preflight:
+  run_erc: true
+  run_drc: true
+  check_zone_fills: true


### PR DESCRIPTION
First half of the **"Both"** design-review plan: real KiCad **ERC + DRC** validation on PRs, posted as a PR comment. (Second half — `kicad-happy` AI review — pending the security audit.)

## What it does
- Runs **ERC + DRC** on every PR, using the project's custom **`Mad_RP2040.kicad_dru`** (JLCPCB/PCBWay rules).
- Re-enables the checks the shared `kibot-config/options.yaml` disables, via a small project-local **`design-review.kibot.yaml`** (preflights only, no outputs → fast).
- **Warn-only**: `continue-on-error` so it never blocks merge — the comment is the signal.
- Posts/updates a **single** PR comment (upsert via a hidden marker) using the **`gh` CLI — no third-party actions** (minimal security surface).
- Uploads the full ERC/DRC report as an artifact.

## Security notes
- `permissions: contents: read` + `pull-requests: write` (least privilege).
- No untrusted input (`outcome` is a fixed enum; PR number/marker via `env:`; log content sent as a file body, never shell-interpolated).
- Comment step guarded to same-repo PRs (fork tokens are read-only) and `continue-on-error`.

## This PR self-tests
Because this PR touches the workflow + config (both in the path filter), the gate runs on this very PR — so you'll see the comment appear below and can judge the output format before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)