### PR TITLE
ci: kicad-happy AI design review (fork-safe, SHA-pinned, no AI/egress)

### DIFF
--- a/.github/workflows/kicad-happy-comment.yml
+++ b/.github/workflows/kicad-happy-comment.yml
@@ -1,0 +1,59 @@
+name: KiCad Review Comment
+
+# Companion to kicad-happy.yml. Runs in the trusted base-repo context after the
+# analysis workflow completes, and posts the report as a PR comment. This is the
+# only job that holds `pull-requests: write`, and it runs NO third-party analysis
+# code — it just downloads the artifact and comments.
+#
+# NOTE: workflow_run only fires from the default branch, so this activates once
+# merged to main (it won't post on its own introducing PR).
+on:
+  workflow_run:
+    workflows: ['KiCad Analysis (kicad-happy)']
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read            # required to download artifacts from the triggering run
+  pull-requests: write     # post the comment
+
+jobs:
+  comment:
+    name: Post review comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    steps:
+    - name: Download report
+      uses: actions/download-artifact@v4
+      with:
+        name: kicad-review
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download meta
+      uses: actions/download-artifact@v4
+      with:
+        name: kicad-review-meta
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Read & validate PR number
+      id: pr
+      run: |
+        set -uo pipefail
+        num=$(cat pr-number.txt)
+        # The artifact comes from a (possibly fork) PR run — validate before use.
+        if [[ "$num" =~ ^[0-9]+$ ]]; then
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+        else
+          echo "Refusing to use non-numeric PR number: '$num'"
+          exit 1
+        fi
+
+    - name: Post / update review comment
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
+      with:
+        file-path: report.md
+        comment-tag: kicad-happy-review
+        mode: upsert
+        pr-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/kicad-happy.yml
+++ b/.github/workflows/kicad-happy.yml
@@ -1,0 +1,69 @@
+name: KiCad Analysis (kicad-happy)
+
+# Tier-1 (deterministic) AI-design-review analysis via aklofas/kicad-happy.
+# Fork-safe pattern: this workflow runs on `pull_request` with a READ-ONLY token
+# (safe for fork PRs) and only produces a report artifact. A companion workflow
+# (kicad-happy-comment.yml) posts the comment with write permissions via the
+# trusted `workflow_run` trigger.
+#
+# Mitigations from the security audit of kicad-happy @ v1.3.2:
+#  - kicad-happy SHA-pinned (not @v1).
+#  - No distributor API keys passed  -> no DigiKey/Mouser/element14 egress.
+#  - No AI step (no claude-code-action) -> nothing sent to any LLM.
+#  - Least privilege: contents: read only.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.kicad_sch'
+      - '**.kicad_pcb'
+      - 'mad_lib/**'
+      - '.github/workflows/kicad-happy.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Deterministic analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
+    - name: Install analysis dependencies
+      run: sudo apt-get install -y ngspice poppler-utils
+
+    - name: KiCad design review (no AI, no distributor keys)
+      id: analysis
+      uses: aklofas/kicad-happy@839d9b03c42358ab16f2eedfdea6c4bc6469826f  # v1.3.2
+
+    - name: Upload report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad-review
+        path: ${{ steps.analysis.outputs.report-path }}
+        retention-days: 1
+
+    - name: Save PR number for the comment workflow
+      if: always()
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: echo "$PR_NUMBER" > pr-number.txt
+
+    - name: Upload meta
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: kicad-review-meta
+        path: pr-number.txt
+        retention-days: 1

--- a/.github/workflows/kicad-happy.yml
+++ b/.github/workflows/kicad-happy.yml
@@ -40,7 +40,9 @@ jobs:
         submodules: recursive
 
     - name: Install analysis dependencies
-      run: sudo apt-get install -y ngspice poppler-utils
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ngspice poppler-utils
 
     - name: KiCad design review (no AI, no distributor keys)
       id: analysis


### PR DESCRIPTION
Second half of the **"Both"** design-review plan: deterministic AI-design-review checks from **aklofas/kicad-happy** (power tree, derating, protocol, DFM, SPICE), posted as a PR comment. Complements the ERC/DRC gate (PR #14).

Built under every mitigation from the security audit (verdict: GO-WITH-MITIGATIONS, audited @ v1.3.2 / `839d9b0`):

- **Fork-safe two-workflow pattern.** `kicad-happy.yml` runs analysis on `pull_request` with a **read-only** token; `kicad-happy-comment.yml` posts via the trusted `workflow_run` trigger with `pull-requests: write` and runs **no third-party analysis code**.
- **SHA-pinned third-party actions**: `aklofas/kicad-happy@839d9b0` (v1.3.2), `thollander/actions-comment-pull-request@24bffb9` (v3.0.1).
- **No distributor API keys** → no DigiKey/Mouser/element14 egress.
- **No AI step** (no `claude-code-action`) → nothing sent to any LLM. Deterministic checks only.
- **Least privilege** throughout; PR number read from the artifact is validated `^[0-9]+$` before use.

## Testing
- **Analysis half** is testable on this PR (the `pull_request` trigger works from the branch) — see the check below.
- **Comment half** uses `workflow_run`, which only fires from the **default branch** — so it activates *after merge to `main`*. I'll confirm commenting with a trivial follow-up PR once this is merged.

## Enabling AI later (optional, separate decision)
Add an `anthropics/claude-code-action` step + `ANTHROPIC_API_KEY`. That's the only path that sends design-derived data to an LLM, and that action needs its own audit first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)