### PR TITLE
test: verify comment bots on main (throwaway)

### DIFF
--- a/.github/workflows/design-review.yaml
+++ b/.github/workflows/design-review.yaml
@@ -153,3 +153,5 @@ jobs:
           echo "Creating new comment"
           gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@comment.md >/dev/null
         fi
+
+# CI verification touch — throwaway, will be reverted.

--- a/.github/workflows/kicad-happy.yml
+++ b/.github/workflows/kicad-happy.yml
@@ -69,3 +69,5 @@ jobs:
         name: kicad-review-meta
         path: pr-number.txt
         retention-days: 1
+
+# CI verification touch — throwaway, will be reverted.


### PR DESCRIPTION
Throwaway PR to confirm both PR-comment bots post now that everything is on `main`. Touches only trailing comments in two workflow files (no board-file changes) to trigger both gates. **Will be closed/reverted** — do not merge.