### PR TITLE
ci: idempotent, dispatchable release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,21 @@
 name: Publish Release
 
-# Auto-publish build artifacts to a GitHub Release whenever a version tag is pushed.
-#   git tag v1.0.0 && git push origin v1.0.0
-# Builds the datapacks fresh from the tagged commit, zips each into a versioned
-# archive, and publishes a release with auto-generated notes.
+# Publish build artifacts to a GitHub Release for a version tag.
+#   - Automatically when a version tag is pushed:  git tag v1.0.0 && git push origin v1.0.0
+#   - On demand for any existing tag (incl. older tags whose commit predates this
+#     workflow): Actions -> Publish Release -> Run workflow -> enter the tag.
+# Builds the datapacks fresh from the chosen tag's tree, zips each into a
+# versioned archive, and creates or updates the release.
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build & (re)publish a release for, e.g. v0.0.0'
+        required: true
+        type: string
 
 # Required so the workflow can create the release and upload assets.
 permissions:
@@ -15,7 +23,7 @@ permissions:
 
 # Never cancel a release mid-publish; serialize per tag.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
   cancel-in-progress: false
 
 # NOTE: kibot-config is SHA-pinned (not @main) so a tagged release rebuilds
@@ -29,14 +37,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # On a tag push, build that tag. On manual dispatch, build the tag the user
+    # entered (this is how older tags whose commit predates this workflow get a
+    # release — the workflow runs from the default branch, the code from the tag).
     - name: Checkout (full history for submodules + release notes)
       uses: actions/checkout@v5
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
         submodules: recursive
         fetch-depth: 0
 
     - name: Get KiCad project name
       run: echo "PROJECT_NAME=$(basename *.kicad_pro .kicad_pro)" >> $GITHUB_ENV
+
+    # The tag this release is for, regardless of how the workflow was triggered.
+    # The dispatch input is passed via env (never expanded into the script) so a
+    # crafted tag value can't be smuggled in as shell — avoids workflow injection.
+    - name: Resolve release tag
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        DISPATCH_TAG: ${{ inputs.tag }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          TAG="$DISPATCH_TAG"
+        else
+          TAG="$REF_NAME"
+        fi
+        # Only accept simple version-tag names (no shell metachars, no path tricks).
+        case "$TAG" in
+          v[0-9]*) : ;;
+          *) echo "Refusing unexpected release tag: '$TAG'" >&2; exit 1 ;;
+        esac
+        echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
 
     - name: Clone and Checkout KiBot config
       uses: actions/checkout@v5
@@ -111,7 +145,7 @@ jobs:
         zip_if_present() {
           local src="$1" suffix="$2"
           if [ -d "$src" ] && [ -n "$(ls -A "$src" 2>/dev/null)" ]; then
-            zip -r "release_assets/${PROJECT_NAME}-${GITHUB_REF_NAME}-${suffix}.zip" "$src"
+            zip -r "release_assets/${PROJECT_NAME}-${RELEASE_TAG}-${suffix}.zip" "$src"
             echo "Packaged ${suffix}"
           else
             echo "Skipping ${suffix} (no output at ${src})"
@@ -124,11 +158,22 @@ jobs:
         echo "--- release_assets ---"
         ls -la release_assets
 
+    # Idempotent publish: create the release if it's new, otherwise refresh its
+    # assets in place. (The old `gh release create` died when the release already
+    # existed — that's what failed the first v0.0.1 run.)
     - name: Publish GitHub Release
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release create "${GITHUB_REF_NAME}" \
-          release_assets/*.zip \
-          --title "${PROJECT_NAME} ${GITHUB_REF_NAME}" \
-          --generate-notes
+        set -euo pipefail
+        if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+          echo "Release ${RELEASE_TAG} exists — updating assets in place."
+          gh release upload "${RELEASE_TAG}" release_assets/*.zip --clobber
+          gh release edit "${RELEASE_TAG}" --title "${PROJECT_NAME} ${RELEASE_TAG}" --draft=false
+        else
+          echo "Creating release ${RELEASE_TAG}."
+          gh release create "${RELEASE_TAG}" \
+            release_assets/*.zip \
+            --title "${PROJECT_NAME} ${RELEASE_TAG}" \
+            --generate-notes
+        fi


### PR DESCRIPTION
The release publish step used `gh release create`, which errors when the release already exists — that's what failed the first v0.0.1 run (build steps passed, publish died). Make it create-or-update: `gh release upload --clobber` when the release exists, create it otherwise.

Also add `workflow_dispatch` with a `tag` input so a release can be built for any existing tag — including older tags (e.g. v0.0.0) whose commit predates this workflow. On dispatch the workflow runs from main but checks out the board from the chosen tag. The input is passed via env and validated against `v[0-9]*` so it can't be expanded as shell.